### PR TITLE
Add support for defining simple macros

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -1,4 +1,5 @@
 #lang racket/base
-(require (for-syntax racket/base syntax/parse))
-(provide (all-from-out racket/base)
-         (for-syntax (all-from-out racket/base) (all-from-out syntax/parse)))
+(require syntax/parse/define
+         (for-syntax racket/base syntax/parse))
+(provide (all-from-out racket/base syntax/parse/define)
+         (for-syntax (all-from-out racket/base syntax/parse)))


### PR DESCRIPTION
Providing [simplicity](http://docs.racket-lang.org/syntax/Defining_Simple_Macros.html) and [expressiveness](http://docs.racket-lang.org/syntax/stxparse-specifying.html) in a way fully compatible with the [Syntax tools](http://docs.racket-lang.org/syntax/Parsing_Syntax.html) already included in the Agile development environment.
