### PR TITLE
add pattern expanders for more syntax extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 compiled
+doc
 *~
 \.\#*
 \#*

--- a/lib/syntax-extension.rkt
+++ b/lib/syntax-extension.rkt
@@ -1,0 +1,15 @@
+#lang racket/base
+
+(provide (all-from-out syntax/parse/define)
+         define-simple-id-macro
+         define-pattern-expander)
+
+(require syntax/parse syntax/parse/define
+         (for-syntax racket/base syntax/transformer))
+
+(define-simple-macro (define-simple-id-macro m:id e:expr)
+  (define-syntax m (make-variable-like-transformer #'e)))
+
+(define-simple-macro (define-pattern-expander name:id clause ...)
+  (define-syntax name
+    (pattern-expander (syntax-parser clause ...))))

--- a/main.rkt
+++ b/main.rkt
@@ -1,7 +1,9 @@
 #lang racket/base
-(require syntax/parse/define
+(require agile/lib/syntax-extension
          racket/match
          racket/list
-         (for-syntax racket/base syntax/parse))
-(provide (all-from-out racket/base syntax/parse/define racket/list racket/match)
-         (for-syntax (all-from-out racket/base syntax/parse)))
+         (for-meta 1 racket/base agile/lib/syntax-extension)
+         (for-meta 2 racket/base))
+(provide (all-from-out racket/base agile/lib/syntax-extension racket/list racket/match)
+         (for-meta 1 (all-from-out racket/base agile/lib/syntax-extension))
+         (for-meta 2 (all-from-out racket/base)))


### PR DESCRIPTION
The [_Syntax Extension tools_](http://docs.racket-lang.org/syntax/Parsing_Syntax.html) in Agile are great for meeting changing requirements. However they would be even better with [_pattern expanders_](http://docs.racket-lang.org/syntax/stxparse-patterns.html#%28part._.Pattern_.Expanders%29). This pull request adds `define-pattern-expander` to the language.